### PR TITLE
Deletion protection + PITR on the user data tables

### DIFF
--- a/terraform/api_gateway.tf
+++ b/terraform/api_gateway.tf
@@ -8,32 +8,32 @@ resource "aws_api_gateway_account" "api_gateway_account" {
 
 locals {
   user_endpoints = [for l in local.user_lambdas : {
-    name = l.name, path_part = l.path_part, http_method = l.http_method,
+    name       = l.name, path_part = l.path_part, http_method = l.http_method,
     invoke_arn = aws_lambda_function.user[l.name].invoke_arn
   }]
 
   workout_endpoints = [for l in local.workout_lambdas : {
-    name = l.name, path_part = l.path_part, http_method = l.http_method,
+    name       = l.name, path_part = l.path_part, http_method = l.http_method,
     invoke_arn = aws_lambda_function.workout[l.name].invoke_arn
   }]
 
   feed_endpoints = [for l in local.feed_lambdas : {
-    name = l.name, path_part = l.path_part, http_method = l.http_method,
+    name       = l.name, path_part = l.path_part, http_method = l.http_method,
     invoke_arn = aws_lambda_function.feed[l.name].invoke_arn
   }]
 
   friends_endpoints = [for l in local.friends_lambdas : {
-    name = l.name, path_part = l.path_part, http_method = l.http_method,
+    name       = l.name, path_part = l.path_part, http_method = l.http_method,
     invoke_arn = aws_lambda_function.friends[l.name].invoke_arn
   }]
 
   prs_endpoints = [for l in local.prs_lambdas : {
-    name = l.name, path_part = l.path_part, http_method = l.http_method,
+    name       = l.name, path_part = l.path_part, http_method = l.http_method,
     invoke_arn = aws_lambda_function.prs[l.name].invoke_arn
   }]
 
   exercises_endpoints = [for l in local.exercises_lambdas : {
-    name = l.name, path_part = l.path_part, http_method = l.http_method,
+    name       = l.name, path_part = l.path_part, http_method = l.http_method,
     invoke_arn = aws_lambda_function.exercises[l.name].invoke_arn
   }]
 }

--- a/terraform/dynamodb.tf
+++ b/terraform/dynamodb.tf
@@ -3,6 +3,11 @@
 # ============================================
 
 resource "aws_dynamodb_table" "users" {
+  deletion_protection_enabled = true
+
+  point_in_time_recovery {
+    enabled = true
+  }
   name         = "${var.app_name}-users"
   billing_mode = "PAY_PER_REQUEST"
   hash_key     = "user_id"
@@ -16,6 +21,11 @@ resource "aws_dynamodb_table" "users" {
 }
 
 resource "aws_dynamodb_table" "workouts" {
+  deletion_protection_enabled = true
+
+  point_in_time_recovery {
+    enabled = true
+  }
   name         = "${var.app_name}-workouts"
   billing_mode = "PAY_PER_REQUEST"
   hash_key     = "workout_id"
@@ -46,6 +56,11 @@ resource "aws_dynamodb_table" "workouts" {
 }
 
 resource "aws_dynamodb_table" "social" {
+  deletion_protection_enabled = true
+
+  point_in_time_recovery {
+    enabled = true
+  }
   name         = "${var.app_name}-social"
   billing_mode = "PAY_PER_REQUEST"
   hash_key     = "user_id"
@@ -65,6 +80,11 @@ resource "aws_dynamodb_table" "social" {
 }
 
 resource "aws_dynamodb_table" "feed" {
+  deletion_protection_enabled = true
+
+  point_in_time_recovery {
+    enabled = true
+  }
   name         = "${var.app_name}-feed"
   billing_mode = "PAY_PER_REQUEST"
   hash_key     = "user_id"

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -19,39 +19,39 @@ locals {
 
   # ── Lambda definitions ──────────────────────────
   user_lambdas = [
-    { name = "create",  description = "Create user",         path_part = "create",  http_method = "POST" },
-    { name = "data",    description = "Get user data",       path_part = "data",    http_method = "GET" },
-    { name = "update",  description = "Update user",         path_part = "update",  http_method = "POST" },
-    { name = "search",  description = "Search users",        path_part = "search",  http_method = "GET" },
+    { name = "create", description = "Create user", path_part = "create", http_method = "POST" },
+    { name = "data", description = "Get user data", path_part = "data", http_method = "GET" },
+    { name = "update", description = "Update user", path_part = "update", http_method = "POST" },
+    { name = "search", description = "Search users", path_part = "search", http_method = "GET" },
   ]
 
   workout_lambdas = [
-    { name = "create",  description = "Create workout",      path_part = "create",  http_method = "POST" },
-    { name = "get",     description = "Get workout",         path_part = "get",     http_method = "GET" },
-    { name = "list",    description = "List workouts",       path_part = "list",    http_method = "GET" },
-    { name = "delete",  description = "Delete workout",      path_part = "delete",  http_method = "POST" },
+    { name = "create", description = "Create workout", path_part = "create", http_method = "POST" },
+    { name = "get", description = "Get workout", path_part = "get", http_method = "GET" },
+    { name = "list", description = "List workouts", path_part = "list", http_method = "GET" },
+    { name = "delete", description = "Delete workout", path_part = "delete", http_method = "POST" },
   ]
 
   feed_lambdas = [
-    { name = "get",     description = "Get feed",            path_part = "get",     http_method = "GET" },
-    { name = "like",    description = "Like post",           path_part = "like",    http_method = "POST" },
-    { name = "comment", description = "Comment on post",     path_part = "comment", http_method = "POST" },
+    { name = "get", description = "Get feed", path_part = "get", http_method = "GET" },
+    { name = "like", description = "Like post", path_part = "like", http_method = "POST" },
+    { name = "comment", description = "Comment on post", path_part = "comment", http_method = "POST" },
   ]
 
   friends_lambdas = [
     { name = "request", description = "Send friend request", path_part = "request", http_method = "POST" },
-    { name = "accept",  description = "Accept request",      path_part = "accept",  http_method = "POST" },
-    { name = "reject",  description = "Reject request",      path_part = "reject",  http_method = "POST" },
-    { name = "list",    description = "List friends",        path_part = "list",    http_method = "GET" },
-    { name = "pending", description = "Pending requests",    path_part = "pending", http_method = "GET" },
-    { name = "remove",  description = "Remove friend",       path_part = "remove",  http_method = "POST" },
+    { name = "accept", description = "Accept request", path_part = "accept", http_method = "POST" },
+    { name = "reject", description = "Reject request", path_part = "reject", http_method = "POST" },
+    { name = "list", description = "List friends", path_part = "list", http_method = "GET" },
+    { name = "pending", description = "Pending requests", path_part = "pending", http_method = "GET" },
+    { name = "remove", description = "Remove friend", path_part = "remove", http_method = "POST" },
   ]
 
   prs_lambdas = [
-    { name = "list",    description = "List PRs",            path_part = "list",    http_method = "GET" },
+    { name = "list", description = "List PRs", path_part = "list", http_method = "GET" },
   ]
 
   exercises_lambdas = [
-    { name = "list",    description = "List exercises",      path_part = "list",    http_method = "GET" },
+    { name = "list", description = "List exercises", path_part = "list", http_method = "GET" },
   ]
 }


### PR DESCRIPTION
Part of an estate-wide audit. **This repo had the worst combination found.**

## Four tables with neither a delete guard nor a backup

`users`, `workouts`, `social`, `feed` had **no deletion protection and no point-in-time recovery**. Real user data with no guard against deletion and no restore path if it were corrupted — the only repo in the estate where both were missing on user-facing tables.

This PR adds both:

- `deletion_protection_enabled = true` — free, refuses a delete that was almost certainly a mistake
- `point_in_time_recovery` — costs roughly $0.20/GB-month, which at these table sizes is pennies

They are not substitutes: PITR restores a table, it does not survive one being *deleted*. Log-shaped tables elsewhere in the estate were deliberately left without PITR, but workout history and social graph are exactly the data worth paying to be able to restore.

Plan should show **in-place updates only**. Once applied, deleting these through Terraform fails until the flag is deliberately turned off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EFvyLPpVdF4PAtGjnNze69